### PR TITLE
fix(shadow): 修复 Gradle 9 上 shadowJar 失败

### DIFF
--- a/ihub-agent-trace-plugin/build.gradle.kts
+++ b/ihub-agent-trace-plugin/build.gradle.kts
@@ -15,8 +15,13 @@
  */
 description = "IHub代理核心组件"
 
+// 注意：此处直接使用 com.gradleup.shadow（shadow 官方延续分支）而非 alias(ihub.plugins.shadow)。
+// 原因：ihub-shadow 插件（ihub-settings 1.9.5）硬编码依赖 com.github.johnrengelman:shadow:8.1.1，
+// 该版本在 Gradle 9 上 visitDir 访问已移除的 details.mode 属性导致 shadowJar 失败。
+// com.gradleup.shadow 保留 com.github.jengelman.gradle.plugins.shadow 包，兼容 Gradle 9。
+// TODO: 待 plugins 仓库 ihub-shadow 升级 shadow 版本后，恢复使用 alias(ihub.plugins.shadow)。
 plugins {
-    alias(ihub.plugins.shadow)
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 dependencies {
@@ -24,4 +29,11 @@ dependencies {
     implementation("org.apache.tomcat.embed:tomcat-embed-core")
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
+}
+
+// 内联 ihub-shadow 插件的 Java agent manifest 注入逻辑（原 IHubShadowPlugin 自动检测 premain/agentmain）。
+tasks.named<Jar>("shadowJar") {
+    manifest.attributes("Premain-Class" to "pub.ihub.integration.agent.trace.IHubTraceAgent")
+    manifest.attributes("Can-Redefine-Classes" to true)
+    manifest.attributes("Can-Retransform-Classes" to true)
 }


### PR DESCRIPTION
## 问题

integrations 0.2.0~0.2.3 发布连续失败，根因：

`ihub-shadow` 插件（ihub-settings 1.9.5）硬编码依赖 `com.github.johnrengelman:shadow:8.1.1`，该版本在 Gradle 9 上 `ShadowCopyAction.visitDir` 访问已移除的 `details.mode` 属性，导致 `ihub-agent-trace-plugin:shadowJar` 报：

```
groovy.lang.MissingPropertyException: No such property: mode for class: ...StubbedFileCopyDetails
```

## 修复

由于 integrations 升级 ihub-settings 到 2.0.0-m2 被测试依赖冲突阻塞（[[errorprone/truth/compile-testing]]），改为在 `ihub-agent-trace-plugin` 直接使用 `com.gradleup.shadow:8.3.6`（shadow 官方延续分支，兼容 Gradle 9，保留 `com.github.jengelman.gradle.plugins.shadow` 包），并内联 Java agent manifest 注入逻辑（Premain-Class / Can-Redefine-Classes / Can-Retransform-Classes）。

## 验证

- ✅ 本地 `shadowJar` 通过，产物 `-all.jar` manifest 正确
- ✅ 本地 `publishToMavenLocal` 通过，发布结构完整（-all.jar + jar + module + pom）
- ⚠️ 本地 JDK 25 下 ihub-process-* 注解处理器测试因 SourceVersion 不匹配失败，CI 使用 JDK 21 不受影响

## 后续

待 plugins 仓库 ihub-shadow 升级 shadow 版本后，恢复使用 `alias(ihub.plugins.shadow)`，移除内联 manifest 逻辑。

合并后发布 0.2.4。